### PR TITLE
fix: load page immediately after RPC success

### DIFF
--- a/src/contexts/LiveDataContext.tsx
+++ b/src/contexts/LiveDataContext.tsx
@@ -21,7 +21,12 @@ export const LiveDataProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   const [live_data, setLiveData] = useState<LiveDataResponse | null>(null);
   const [showCallout, setShowCallout] = useState(false);
   const [refreshCallbacks] = useState<Set<(data: LiveDataResponse) => void>>(new Set());
-  const { call } = useRPC2Call();
+  const { call, isConnected } = useRPC2Call();
+
+  // 当 RPC2 连接状态变化时同步更新 callout，避免第一次成功后仍显示未连接提示
+  useEffect(() => {
+    setShowCallout(isConnected);
+  }, [isConnected]);
 
   // 注册刷新回调函数
   const onRefresh = (callback: (data: LiveDataResponse) => void) => {

--- a/src/lib/liveDataBridge.ts
+++ b/src/lib/liveDataBridge.ts
@@ -52,6 +52,11 @@ export class LiveDataBridge {
   start() {
     this.mode = "rpc";
     this.rpcFailureCount = 0;
+    // 首次启动立即尝试获取一次 RPC 数据，避免必须等到下一个计时周期
+    this.fetchRpcLatest().catch((e) => {
+      // 错误在内部处理并会在后续调度中重试
+      console.debug("LiveDataBridge: initial fetchRpcLatest failed:", e);
+    });
     this.scheduleRpc();
   }
 


### PR DESCRIPTION
Now the page loads immediately instead of waiting for the second RPC response