### PR TITLE
refactor(ui): clean up node detail page layout and CJK rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,11 @@ Thumbs.db
 coverage/
 *.lcov
 
+# Bun
+bun.lockb
+.bun-cache/
+.bun/
+
 # Yarn
 .yarn/*
 !.yarn/patches

--- a/src/components/DesktopChart.css
+++ b/src/components/DesktopChart.css
@@ -44,7 +44,7 @@
 /* 图表卡片样式 */
 .desktop-chart-card {
   background: var(--color-panel-solid);
-  border-radius: 12px;
+  border-radius: 8px;
   padding: 1rem 1.25rem;
   border: 1px solid var(--gray-a4);
   transition: all 0.2s ease;

--- a/src/components/DesktopDetailsCard.tsx
+++ b/src/components/DesktopDetailsCard.tsx
@@ -1,7 +1,7 @@
 import { Tooltip } from "@radix-ui/themes";
 import { useLayoutEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { formatBytes } from "./Node";
+import { formatBytes, formatUptime } from "./Node";
 import { getTrafficStats } from "@/utils";
 import type { NodeBasicInfo } from "@/contexts/NodeListContext";
 import type { Record } from "@/types/LiveData";
@@ -73,11 +73,9 @@ export const DesktopDetailsCard: React.FC<DesktopDetailsCardProps> = ({
     value == null ? "-" : `${value.toFixed(1)}%`;
   const formatLoad = (value?: number) =>
     typeof value === "number" && Number.isFinite(value) ? value.toFixed(2) : "-";
-  const loadLines = [
-    `1m: ${formatLoad(liveData?.load?.load1)}`,
-    `5m: ${formatLoad(liveData?.load?.load5)}`,
-    `15m: ${formatLoad(liveData?.load?.load15)}`,
-  ];
+  const loadLine = `1m: ${formatLoad(liveData?.load?.load1)} / 5m: ${formatLoad(liveData?.load?.load5)} / 15m: ${formatLoad(liveData?.load?.load15)}`;
+  const uptimeLabel = liveData?.uptime ? formatUptime(liveData.uptime, t) : "-";
+  const updatedLabel = liveData?.updated_at ? new Date(liveData.updated_at).toLocaleString() : "-";
   const latencyRows = pingSummary.items.map((item) => ({
     name: item.name,
     current: formatLatency(item.current),
@@ -195,7 +193,9 @@ export const DesktopDetailsCard: React.FC<DesktopDetailsCardProps> = ({
           <div className="node-detail-section-title">{t("nodeCard.runtime_info")}</div>
           <div className="node-detail-runtime-stack" ref={runtimeStackRef}>
             <DetailRow label={t("nodeCard.process")} value={liveData?.process?.toString() || "-"} />
-            <DetailRow label={t("nodeCard.load")} value={loadLines} />
+            <DetailRow label={t("nodeCard.load")} value={loadLine} />
+            <DetailRow label={t("nodeCard.uptime")} value={uptimeLabel} />
+            <DetailRow label={t("nodeCard.last_updated")} value={updatedLabel} />
           </div>
         </div>
         <div className="node-detail-card node-detail-latency-inline">

--- a/src/components/DesktopDetailsCard.tsx
+++ b/src/components/DesktopDetailsCard.tsx
@@ -1,7 +1,7 @@
 import { Tooltip } from "@radix-ui/themes";
 import { useLayoutEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { formatBytes, formatUptime } from "./Node";
+import { formatBytes } from "./Node";
 import { getTrafficStats } from "@/utils";
 import type { NodeBasicInfo } from "@/contexts/NodeListContext";
 import type { Record } from "@/types/LiveData";
@@ -194,13 +194,8 @@ export const DesktopDetailsCard: React.FC<DesktopDetailsCardProps> = ({
           <div className="node-detail-card">
           <div className="node-detail-section-title">{t("nodeCard.runtime_info")}</div>
           <div className="node-detail-runtime-stack" ref={runtimeStackRef}>
-            <DetailRow label={t("nodeCard.uptime")} value={liveData?.uptime ? formatUptime(liveData.uptime, t) : "-"} />
             <DetailRow label={t("nodeCard.process")} value={liveData?.process?.toString() || "-"} />
             <DetailRow label={t("nodeCard.load")} value={loadLines} />
-            <DetailRow
-              label={t("nodeCard.last_updated")}
-              value={liveData?.updated_at ? new Date(liveData.updated_at).toLocaleString() : "-"}
-            />
           </div>
         </div>
         <div className="node-detail-card node-detail-latency-inline">

--- a/src/components/MobileDetailsCard.tsx
+++ b/src/components/MobileDetailsCard.tsx
@@ -1,10 +1,8 @@
-import { Dialog, Button } from "@radix-ui/themes";
 import { useTranslation } from "react-i18next";
-import { formatBytes, formatUptime } from "./Node";
+import { formatBytes } from "./Node";
 import { getTrafficStats } from "@/utils";
 import type { NodeBasicInfo } from "@/contexts/NodeListContext";
 import type { Record } from "@/types/LiveData";
-import { useState } from "react";
 import { MetricBar } from "./MetricBar";
 import { TrafficLimitChart } from "./TrafficLimitChart";
 import { usePingSummary } from "@/hooks/use-ping-summary";
@@ -130,36 +128,27 @@ export const MobileDetailsCard: React.FC<MobileDetailsCardProps> = ({
 
       <div className="node-detail-card node-detail-animate" style={{ ["--delay" as any]: "160ms" }}>
         <div className="node-detail-section-title">{t("nodeCard.system_info")}</div>
-        <DetailRow label={t("nodeCard.os")} value={node.os} closeLabel={t("admin.nodeDetail.done")} />
-        <DetailRow label={t("nodeCard.kernelVersion")} value={node.kernel_version || "Unknown"} closeLabel={t("admin.nodeDetail.done")} />
-        <DetailRow label={t("nodeCard.arch")} value={node.arch} closeLabel={t("admin.nodeDetail.done")} />
-        <DetailRow label={t("nodeCard.virtualization")} value={node.virtualization || "Unknown"} closeLabel={t("admin.nodeDetail.done")} />
+        <DetailRow label={t("nodeCard.os")} value={node.os} />
+        <DetailRow label={t("nodeCard.kernelVersion")} value={node.kernel_version || "Unknown"} />
+        <DetailRow label={t("nodeCard.arch")} value={node.arch} />
+        <DetailRow label={t("nodeCard.virtualization")} value={node.virtualization || "Unknown"} />
       </div>
 
       <div className="node-detail-card node-detail-animate" style={{ ["--delay" as any]: "200ms" }}>
         <div className="node-detail-section-title">{t("nodeCard.hardware_info")}</div>
-        <DetailRow label={t("nodeCard.cpu")} value={`${node.cpu_name} (x${node.cpu_cores})`} closeLabel={t("admin.nodeDetail.done")} />
-        <DetailRow label={t("admin.nodeDetail.gpu")} value={node.gpu_name || "Unknown"} closeLabel={t("admin.nodeDetail.done")} />
-        <DetailRow label={t("nodeCard.ram")} value={formatBytes(node.mem_total)} closeLabel={t("admin.nodeDetail.done")} />
-        <DetailRow label={t("nodeCard.disk")} value={formatBytes(node.disk_total)} closeLabel={t("admin.nodeDetail.done")} />
+        <DetailRow label={t("nodeCard.cpu")} value={`${node.cpu_name} (x${node.cpu_cores})`} />
+        <DetailRow label={t("admin.nodeDetail.gpu")} value={node.gpu_name || "Unknown"} />
+        <DetailRow label={t("nodeCard.ram")} value={formatBytes(node.mem_total)} />
+        <DetailRow label={t("nodeCard.disk")} value={formatBytes(node.disk_total)} />
       </div>
 
       <div className="node-detail-card node-detail-animate" style={{ ["--delay" as any]: "240ms" }}>
         <div className="node-detail-section-title">{t("nodeCard.network_info")}</div>
-        <DetailRow
-          label={t("nodeCard.networkSpeed")}
-          value={networkSpeedLines}
-          closeLabel={t("admin.nodeDetail.done")}
-        />
-        <DetailRow
-          label={t("nodeCard.totalTraffic")}
-          value={totalTrafficLines}
-          closeLabel={t("admin.nodeDetail.done")}
-        />
+        <DetailRow label={t("nodeCard.networkSpeed")} value={networkSpeedLines} />
+        <DetailRow label={t("nodeCard.totalTraffic")} value={totalTrafficLines} />
         <DetailRow
           label={t("nodeCard.connections")}
           value={liveData ? `TCP: ${liveData.connections.tcp}, UDP: ${liveData.connections.udp}` : "-"}
-          closeLabel={t("admin.nodeDetail.done")}
         />
       </div>
 
@@ -167,14 +156,8 @@ export const MobileDetailsCard: React.FC<MobileDetailsCardProps> = ({
         <div className="node-detail-card">
           <div className="node-detail-section-title">{t("nodeCard.runtime_info")}</div>
           <div className="node-detail-runtime-stack">
-            <DetailRow label={t("nodeCard.uptime")} value={liveData?.uptime ? formatUptime(liveData.uptime, t) : "-"} closeLabel={t("admin.nodeDetail.done")} />
-            <DetailRow label={t("nodeCard.process")} value={liveData?.process?.toString() || "-"} closeLabel={t("admin.nodeDetail.done")} />
-            <DetailRow label={t("nodeCard.load")} value={loadLines} closeLabel={t("admin.nodeDetail.done")} />
-            <DetailRow
-              label={t("nodeCard.last_updated")}
-              value={liveData?.updated_at ? new Date(liveData.updated_at).toLocaleString() : "-"}
-              closeLabel={t("admin.nodeDetail.done")}
-            />
+            <DetailRow label={t("nodeCard.process")} value={liveData?.process?.toString() || "-"} />
+            <DetailRow label={t("nodeCard.load")} value={loadLines} />
           </div>
         </div>
         <div className="node-detail-card node-detail-latency-inline">
@@ -215,84 +198,28 @@ export const MobileDetailsCard: React.FC<MobileDetailsCardProps> = ({
 const DetailRow = ({
   label,
   value,
-  closeLabel,
 }: {
   label: string;
   value: string | string[];
-  closeLabel: string;
 }) => {
-  const [dialogOpen, setDialogOpen] = useState(false);
-  const [longPressTimer, setLongPressTimer] = useState<NodeJS.Timeout | null>(null);
   const valueLines = Array.isArray(value) ? value : [value];
-  const rawValue = Array.isArray(value) ? value.join(" ") : value;
-  const isTruncated = rawValue.length > 22;
-
-  const handleTouchStart = () => {
-    if (isTruncated) {
-      const timer = setTimeout(() => {
-        setDialogOpen(true);
-      }, 500);
-      setLongPressTimer(timer);
-    }
-  };
-
-  const handleTouchEnd = () => {
-    if (longPressTimer) {
-      clearTimeout(longPressTimer);
-      setLongPressTimer(null);
-    }
-  };
-
-  const handleClick = () => {
-    if (isTruncated) {
-      setDialogOpen(true);
-    }
-  };
 
   return (
-    <>
-      <div
-        className="node-detail-row"
-        style={{ cursor: isTruncated ? "pointer" : "default" }}
-        onTouchStart={handleTouchStart}
-        onTouchEnd={handleTouchEnd}
-        onClick={handleClick}
-      >
-        <div className="node-detail-row-label">{label}</div>
-        <div className={`node-detail-row-value${valueLines.length > 1 ? " stack" : ""}`}>
-          {valueLines.length > 1 ? (
-            <div className="node-detail-value-stack">
-              {valueLines.map((line) => (
-                <span key={line} className="node-detail-value-line">
-                  {line}
-                </span>
-              ))}
-            </div>
-          ) : (
-            valueLines[0]
-          )}
-        </div>
+    <div className="node-detail-row">
+      <div className="node-detail-row-label">{label}</div>
+      <div className={`node-detail-row-value${valueLines.length > 1 ? " stack" : ""}`}>
+        {valueLines.length > 1 ? (
+          <div className="node-detail-value-stack">
+            {valueLines.map((line) => (
+              <span key={line} className="node-detail-value-line">
+                {line}
+              </span>
+            ))}
+          </div>
+        ) : (
+          valueLines[0]
+        )}
       </div>
-
-      {isTruncated && (
-        <Dialog.Root open={dialogOpen} onOpenChange={setDialogOpen}>
-          <Dialog.Content style={{ maxWidth: "90vw" }}>
-            <Dialog.Title>{label}</Dialog.Title>
-            <Dialog.Description>
-              <div style={{ wordBreak: "break-all", whiteSpace: "pre-wrap", fontSize: "14px", lineHeight: "1.5" }}>
-                {valueLines.map((line, index) => (
-                  <div key={`${line}-${index}`}>{line}</div>
-                ))}
-              </div>
-            </Dialog.Description>
-            <div style={{ display: "flex", justifyContent: "flex-end", marginTop: "16px" }}>
-              <Dialog.Close>
-                <Button variant="soft">{closeLabel}</Button>
-              </Dialog.Close>
-            </div>
-          </Dialog.Content>
-        </Dialog.Root>
-      )}
-    </>
+    </div>
   );
 };

--- a/src/components/MobileDetailsCard.tsx
+++ b/src/components/MobileDetailsCard.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next";
-import { formatBytes } from "./Node";
+import { formatBytes, formatUptime } from "./Node";
 import { getTrafficStats } from "@/utils";
 import type { NodeBasicInfo } from "@/contexts/NodeListContext";
 import type { Record } from "@/types/LiveData";
@@ -69,11 +69,9 @@ export const MobileDetailsCard: React.FC<MobileDetailsCardProps> = ({
     value == null ? "-" : `${value.toFixed(1)}%`;
   const formatLoad = (value?: number) =>
     typeof value === "number" && Number.isFinite(value) ? value.toFixed(2) : "-";
-  const loadLines = [
-    `1m: ${formatLoad(liveData?.load?.load1)}`,
-    `5m: ${formatLoad(liveData?.load?.load5)}`,
-    `15m: ${formatLoad(liveData?.load?.load15)}`,
-  ];
+  const loadLine = `1m: ${formatLoad(liveData?.load?.load1)} / 5m: ${formatLoad(liveData?.load?.load5)} / 15m: ${formatLoad(liveData?.load?.load15)}`;
+  const uptimeLabel = liveData?.uptime ? formatUptime(liveData.uptime, t) : "-";
+  const updatedLabel = liveData?.updated_at ? new Date(liveData.updated_at).toLocaleString() : "-";
   const latencyRows = pingSummary.items.map((item) => ({
     name: item.name,
     current: formatLatency(item.current),
@@ -157,7 +155,9 @@ export const MobileDetailsCard: React.FC<MobileDetailsCardProps> = ({
           <div className="node-detail-section-title">{t("nodeCard.runtime_info")}</div>
           <div className="node-detail-runtime-stack">
             <DetailRow label={t("nodeCard.process")} value={liveData?.process?.toString() || "-"} />
-            <DetailRow label={t("nodeCard.load")} value={loadLines} />
+            <DetailRow label={t("nodeCard.load")} value={loadLine} />
+            <DetailRow label={t("nodeCard.uptime")} value={uptimeLabel} />
+            <DetailRow label={t("nodeCard.last_updated")} value={updatedLabel} />
           </div>
         </div>
         <div className="node-detail-card node-detail-latency-inline">

--- a/src/pages/instance/EnhancedLoadChart.tsx
+++ b/src/pages/instance/EnhancedLoadChart.tsx
@@ -351,7 +351,7 @@ const EnhancedLoadChart = ({ data = [] }: EnhancedLoadChartProps) => {
     <div className="desktop-chart-wrapper">
       {/* 时间周期选择器 */}
       {availableView.length > 1 && (
-        <div className="w-full px-3 md:px-0 mb-2">
+        <div className="w-full mb-2">
           <div 
             className="w-full overflow-x-auto md:overflow-x-visible pb-2 md:pb-0"
             style={{
@@ -361,15 +361,13 @@ const EnhancedLoadChart = ({ data = [] }: EnhancedLoadChartProps) => {
               maxWidth: "100%",
             }}
           >
-            <Flex justify="center" className="w-full min-w-max md:min-w-0">
+            <Flex justify="start" className="w-full min-w-max md:min-w-0">
               <SegmentedControl.Root
-                radius="full"
+                radius="small"
                 value={hoursView}
                 onValueChange={setHoursView}
-                className="flex-shrink-0"
+                className="node-detail-toggle flex-shrink-0"
                 style={{ 
-                  transform: "scale(0.95)",
-                  transformOrigin: "center",
                   height: "38px",
                   minWidth: "fit-content"
                 }}

--- a/src/pages/instance/PingChartV2.tsx
+++ b/src/pages/instance/PingChartV2.tsx
@@ -369,6 +369,7 @@ const PingChart = ({ uuid }: { uuid: string }) => {
                 setHours(selected.hours);
               }
             }}
+            className="node-detail-toggle"
           >
             {avaliableView.map((v) => (
               <SegmentedControl.Item

--- a/src/pages/instance/index.tsx
+++ b/src/pages/instance/index.tsx
@@ -13,7 +13,6 @@ import { MobileDetailsCard } from "@/components/MobileDetailsCard";
 import { MobileLoadChart } from "@/components/MobileLoadChart";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { DesktopDetailsCard } from "@/components/DesktopDetailsCard";
-import { formatUptime } from "@/components/Node";
 import { getOSImage } from "@/utils";
 
 import "./instance-detail.css";
@@ -35,8 +34,6 @@ export default function InstancePage() {
   const nodeUuid = node?.uuid ?? uuid ?? "";
   const osIcon = getOSImage(node?.os ?? "");
   const versionLabel = node?.version || "-";
-  const uptimeLabel = liveNodeData?.uptime ? formatUptime(liveNodeData.uptime, t) : "-";
-  const updatedLabel = liveNodeData?.updated_at ? new Date(liveNodeData.updated_at).toLocaleString() : "-";
   const statusText = isOnline ? t("nodeCard.online") : t("nodeCard.offline");
 
   useEffect(() => {
@@ -87,16 +84,6 @@ export default function InstancePage() {
                     <span className="node-detail-name">{nodeName}</span>
                     <span className="node-detail-version-badge">{versionLabel}</span>
                     <span className="node-detail-mono node-detail-uuid-pill">{nodeUuid}</span>
-                  </div>
-                  <div className="node-detail-hero-meta">
-                    <span className="node-detail-hero-meta-item">
-                      <span className="node-detail-hero-meta-label">{t("nodeCard.uptime")}</span>
-                      <span className="node-detail-hero-meta-value">{uptimeLabel}</span>
-                    </span>
-                    <span className="node-detail-hero-meta-item">
-                      <span className="node-detail-hero-meta-label">{t("nodeCard.last_updated")}</span>
-                      <span className="node-detail-hero-meta-value">{updatedLabel}</span>
-                    </span>
                   </div>
                 </div>
               </div>

--- a/src/pages/instance/index.tsx
+++ b/src/pages/instance/index.tsx
@@ -14,7 +14,7 @@ import { MobileLoadChart } from "@/components/MobileLoadChart";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { DesktopDetailsCard } from "@/components/DesktopDetailsCard";
 import { getOSImage } from "@/utils";
-import { formatUptime } from "@/components/Node";
+
 import "./instance-detail.css";
 
 export default function InstancePage() {
@@ -33,8 +33,6 @@ export default function InstancePage() {
   const nodeName = node?.name ?? uuid ?? "";
   const nodeUuid = node?.uuid ?? uuid ?? "";
   const osIcon = getOSImage(node?.os ?? "");
-  const uptimeLabel = liveNodeData?.uptime ? formatUptime(liveNodeData.uptime, t) : "-";
-  const updatedLabel = liveNodeData?.updated_at ? new Date(liveNodeData.updated_at).toLocaleString() : "-";
   const versionLabel = node?.version || "-";
   const statusText = isOnline ? t("nodeCard.online") : t("nodeCard.offline");
 
@@ -84,6 +82,7 @@ export default function InstancePage() {
                 <div className="node-detail-title-text">
                   <div className="node-detail-name-row">
                     <span className="node-detail-name">{nodeName}</span>
+                    <span className="node-detail-version-badge">{versionLabel}</span>
                     <span className="node-detail-mono node-detail-uuid-pill">{nodeUuid}</span>
                   </div>
                 </div>
@@ -92,29 +91,15 @@ export default function InstancePage() {
                 {statusText}
               </div>
             </div>
-            <div className="node-detail-hero-info">
-              <div className="node-detail-hero-item">
-                <span className="node-detail-hero-label">{t("nodeCard.version")}</span>
-                <span className="node-detail-hero-value">{versionLabel}</span>
-              </div>
-              <div className="node-detail-hero-item">
-                <span className="node-detail-hero-label">{t("nodeCard.uptime")}</span>
-                <span className="node-detail-hero-value">{uptimeLabel}</span>
-              </div>
-              <div className="node-detail-hero-item">
-                <span className="node-detail-hero-label">{t("nodeCard.last_updated")}</span>
-                <span className="node-detail-hero-value">{updatedLabel}</span>
-              </div>
-            </div>
-          </div>
+        </div>
 
-          <MobileDetailsCard node={node} liveData={liveNodeData} />
+        <MobileDetailsCard node={node} liveData={liveNodeData} />
 
           <div className="node-detail-chart-card node-detail-animate" style={{ ["--delay" as any]: "200ms" }}>
             <div className="node-detail-chart-header">
               <div className="node-detail-section-title">{t("nodeCard.chart")}</div>
               <SegmentedControl.Root
-                radius="full"
+                radius="small"
                 value={chartView}
                 onValueChange={(value) => setChartView(value as "load" | "ping")}
                 className="node-detail-toggle"
@@ -156,26 +141,13 @@ export default function InstancePage() {
               <div className="node-detail-title-text">
                 <div className="node-detail-name-row">
                   <span className="node-detail-name">{nodeName}</span>
+                  <span className="node-detail-version-badge">{versionLabel}</span>
                   <span className="node-detail-mono node-detail-uuid-pill">{nodeUuid}</span>
                 </div>
               </div>
             </div>
             <div className={`node-detail-status ${isOnline ? "online" : "offline"}`}>
               {statusText}
-            </div>
-          </div>
-          <div className="node-detail-hero-info">
-            <div className="node-detail-hero-item">
-              <span className="node-detail-hero-label">{t("nodeCard.version")}</span>
-              <span className="node-detail-hero-value">{versionLabel}</span>
-            </div>
-            <div className="node-detail-hero-item">
-              <span className="node-detail-hero-label">{t("nodeCard.uptime")}</span>
-              <span className="node-detail-hero-value">{uptimeLabel}</span>
-            </div>
-            <div className="node-detail-hero-item">
-              <span className="node-detail-hero-label">{t("nodeCard.last_updated")}</span>
-              <span className="node-detail-hero-value">{updatedLabel}</span>
             </div>
           </div>
         </div>
@@ -186,12 +158,12 @@ export default function InstancePage() {
           <div className="node-detail-chart-header">
             <div className="node-detail-section-title">{t("nodeCard.chart")}</div>
             <SegmentedControl.Root
-              radius="full"
-              value={chartView}
-              onValueChange={(value) => setChartView(value as "load" | "ping")}
-              size="2"
-              className="node-detail-toggle"
-            >
+                radius="small"
+                value={chartView}
+                onValueChange={(value) => setChartView(value as "load" | "ping")}
+                size="2"
+                className="node-detail-toggle"
+              >
               <SegmentedControl.Item value="load">
                 {t("nodeCard.load")}
               </SegmentedControl.Item>

--- a/src/pages/instance/index.tsx
+++ b/src/pages/instance/index.tsx
@@ -13,6 +13,7 @@ import { MobileDetailsCard } from "@/components/MobileDetailsCard";
 import { MobileLoadChart } from "@/components/MobileLoadChart";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { DesktopDetailsCard } from "@/components/DesktopDetailsCard";
+import { formatUptime } from "@/components/Node";
 import { getOSImage } from "@/utils";
 
 import "./instance-detail.css";
@@ -34,6 +35,8 @@ export default function InstancePage() {
   const nodeUuid = node?.uuid ?? uuid ?? "";
   const osIcon = getOSImage(node?.os ?? "");
   const versionLabel = node?.version || "-";
+  const uptimeLabel = liveNodeData?.uptime ? formatUptime(liveNodeData.uptime, t) : "-";
+  const updatedLabel = liveNodeData?.updated_at ? new Date(liveNodeData.updated_at).toLocaleString() : "-";
   const statusText = isOnline ? t("nodeCard.online") : t("nodeCard.offline");
 
   useEffect(() => {
@@ -84,6 +87,16 @@ export default function InstancePage() {
                     <span className="node-detail-name">{nodeName}</span>
                     <span className="node-detail-version-badge">{versionLabel}</span>
                     <span className="node-detail-mono node-detail-uuid-pill">{nodeUuid}</span>
+                  </div>
+                  <div className="node-detail-hero-meta">
+                    <span className="node-detail-hero-meta-item">
+                      <span className="node-detail-hero-meta-label">{t("nodeCard.uptime")}</span>
+                      <span className="node-detail-hero-meta-value">{uptimeLabel}</span>
+                    </span>
+                    <span className="node-detail-hero-meta-item">
+                      <span className="node-detail-hero-meta-label">{t("nodeCard.last_updated")}</span>
+                      <span className="node-detail-hero-meta-value">{updatedLabel}</span>
+                    </span>
                   </div>
                 </div>
               </div>

--- a/src/pages/instance/index.tsx
+++ b/src/pages/instance/index.tsx
@@ -91,9 +91,9 @@ export default function InstancePage() {
                 {statusText}
               </div>
             </div>
-        </div>
+          </div>
 
-        <MobileDetailsCard node={node} liveData={liveNodeData} />
+          <MobileDetailsCard node={node} liveData={liveNodeData} />
 
           <div className="node-detail-chart-card node-detail-animate" style={{ ["--delay" as any]: "200ms" }}>
             <div className="node-detail-chart-header">
@@ -158,12 +158,12 @@ export default function InstancePage() {
           <div className="node-detail-chart-header">
             <div className="node-detail-section-title">{t("nodeCard.chart")}</div>
             <SegmentedControl.Root
-                radius="small"
-                value={chartView}
-                onValueChange={(value) => setChartView(value as "load" | "ping")}
-                size="2"
-                className="node-detail-toggle"
-              >
+              radius="small"
+              value={chartView}
+              onValueChange={(value) => setChartView(value as "load" | "ping")}
+              size="2"
+              className="node-detail-toggle"
+            >
               <SegmentedControl.Item value="load">
                 {t("nodeCard.load")}
               </SegmentedControl.Item>

--- a/src/pages/instance/instance-detail.css
+++ b/src/pages/instance/instance-detail.css
@@ -7,6 +7,9 @@
   font-variant-numeric: tabular-nums;
   color: var(--gray-12);
   overflow-x: hidden;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
 }
 
 .node-detail-shell::before {
@@ -105,6 +108,32 @@
   align-items: center;
   gap: 10px;
   flex-wrap: wrap;
+}
+
+.node-detail-hero-meta {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  font-size: 12px;
+  color: var(--gray-10);
+}
+
+.node-detail-hero-meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.node-detail-hero-meta-label {
+  color: var(--gray-9);
+  font-weight: 400;
+}
+
+.node-detail-hero-meta-value {
+  color: var(--gray-11);
+  font-weight: 500;
+  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
 
 .node-detail-name {
@@ -302,7 +331,6 @@
   max-width: 100%;
   white-space: normal;
   overflow-wrap: break-word;
-  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
 
 .node-detail-row-value.stack {

--- a/src/pages/instance/instance-detail.css
+++ b/src/pages/instance/instance-detail.css
@@ -3,6 +3,7 @@
 .node-detail-shell {
   position: relative;
   padding: 24px 0 64px;
+  --mono-font: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   font-family: "Space Grotesk", "Noto Sans SC", "Noto Sans JP", sans-serif;
   font-variant-numeric: tabular-nums;
   color: var(--gray-12);
@@ -129,7 +130,7 @@
 .node-detail-mono {
   display: inline-flex;
   align-items: center;
-  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-family: var(--mono-font);
   border: 1px solid var(--gray-a4);
   background: var(--gray-a3);
   padding: 2px 10px;
@@ -198,7 +199,7 @@
   border: 1px solid var(--gray-a4);
   border-radius: 4px;
   padding: 2px 8px;
-  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-family: var(--mono-font);
 }
 
 .node-detail-uuid-pill {
@@ -280,7 +281,7 @@
   color: var(--gray-12);
   font-weight: 600;
   text-align: right;
-  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-family: var(--mono-font);
 }
 
 .node-detail-row {
@@ -358,7 +359,7 @@
   gap: 12px;
   font-size: 12px;
   color: var(--gray-10);
-  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-family: var(--mono-font);
 }
 
 .node-detail-value-stack {
@@ -404,7 +405,7 @@
   font-weight: 600;
   color: var(--gray-12);
   white-space: nowrap;
-  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-family: var(--mono-font);
 }
 
 .node-detail-latency-inline {
@@ -459,7 +460,7 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-family: var(--mono-font);
 }
 
 .node-detail-latency-cell.name {

--- a/src/pages/instance/instance-detail.css
+++ b/src/pages/instance/instance-detail.css
@@ -110,32 +110,6 @@
   flex-wrap: wrap;
 }
 
-.node-detail-hero-meta {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  flex-wrap: wrap;
-  font-size: 12px;
-  color: var(--gray-10);
-}
-
-.node-detail-hero-meta-item {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.node-detail-hero-meta-label {
-  color: var(--gray-9);
-  font-weight: 400;
-}
-
-.node-detail-hero-meta-value {
-  color: var(--gray-11);
-  font-weight: 500;
-  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-}
-
 .node-detail-name {
   font-size: 26px;
   font-weight: 600;

--- a/src/pages/instance/instance-detail.css
+++ b/src/pages/instance/instance-detail.css
@@ -47,7 +47,7 @@
 .node-detail-hero {
   position: relative;
   border: 1px solid var(--gray-a3);
-  border-radius: 24px;
+  border-radius: 12px;
   padding: 20px 24px;
   background:
     radial-gradient(120% 140% at 0% 0%, var(--accent-a3), transparent 65%),
@@ -76,42 +76,6 @@
   z-index: 1;
 }
 
-.node-detail-hero-info {
-  position: relative;
-  margin-top: 16px;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 10px;
-  z-index: 1;
-}
-
-.node-detail-hero-item {
-  background: var(--color-panel-solid);
-  border: 1px solid var(--gray-a3);
-  border-radius: 12px;
-  padding: 10px 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  min-width: 0;
-}
-
-.node-detail-hero-label {
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: var(--gray-9);
-}
-
-.node-detail-hero-value {
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--gray-12);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .node-detail-title {
   display: flex;
   align-items: center;
@@ -122,7 +86,7 @@
 .node-detail-os-icon {
   width: 28px;
   height: 28px;
-  border-radius: 10px;
+  border-radius: 6px;
   padding: 4px;
   background: var(--gray-a2);
   border: 1px solid var(--gray-a3);
@@ -166,7 +130,7 @@
   border: 1px solid var(--gray-a4);
   background: var(--gray-a3);
   padding: 2px 10px;
-  border-radius: 999px;
+  border-radius: 6px;
   color: var(--gray-11);
   max-width: 100%;
   overflow: hidden;
@@ -178,7 +142,7 @@
   align-items: center;
   gap: 8px;
   padding: 6px 12px;
-  border-radius: 999px;
+  border-radius: 6px;
   font-size: 12px;
   font-weight: 600;
   text-transform: uppercase;
@@ -192,7 +156,7 @@
   content: "";
   width: 8px;
   height: 8px;
-  border-radius: 999px;
+  border-radius: 50%;
   background: var(--gray-9);
   box-shadow: 0 0 0 3px var(--gray-a3);
 }
@@ -219,40 +183,19 @@
   box-shadow: 0 0 0 3px var(--red-a3);
 }
 
-.node-detail-meta {
-  position: relative;
-  margin-top: 16px;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 10px;
-  z-index: 1;
-}
-
-.node-detail-chip {
-  background: var(--color-panel-solid);
-  border: 1px solid var(--gray-a3);
-  border-radius: 12px;
-  padding: 10px 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  min-width: 0;
-}
-
-.node-detail-chip-label {
+.node-detail-version-badge {
+  display: inline-flex;
+  align-items: center;
   font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: var(--gray-9);
-}
-
-.node-detail-chip-value {
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--gray-12);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  color: var(--gray-10);
+  background: var(--gray-a2);
+  border: 1px solid var(--gray-a4);
+  border-radius: 4px;
+  padding: 2px 8px;
+  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
 
 .node-detail-uuid-pill {
@@ -272,7 +215,7 @@
   width: 100%;
   height: 8px;
   background: var(--gray-a3);
-  border-radius: 999px;
+  border-radius: 4px;
   overflow: hidden;
 }
 
@@ -296,8 +239,8 @@
 .node-detail-card {
   background: var(--color-panel-solid);
   border: 1px solid var(--gray-a3);
-  border-radius: 16px;
-  padding: 16px;
+  border-radius: 12px;
+  padding: 20px;
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -309,7 +252,7 @@
   text-transform: uppercase;
   letter-spacing: 0.12em;
   color: var(--gray-9);
-  font-weight: 600;
+  font-weight: 500;
 }
 
 .node-detail-metric {
@@ -334,6 +277,7 @@
   color: var(--gray-12);
   font-weight: 600;
   text-align: right;
+  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
 
 .node-detail-row {
@@ -356,9 +300,9 @@
   color: var(--gray-12);
   text-align: left;
   max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  white-space: normal;
+  overflow-wrap: break-word;
+  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
 
 .node-detail-row-value.stack {
@@ -385,7 +329,7 @@
   color: var(--gray-10);
   border: 1px solid var(--gray-a4);
   padding: 2px 8px;
-  border-radius: 999px;
+  border-radius: 4px;
   background: var(--gray-a2);
 }
 
@@ -393,7 +337,7 @@
   width: 100%;
   height: 8px;
   background: var(--gray-a3);
-  border-radius: 999px;
+  border-radius: 4px;
   overflow: hidden;
 }
 
@@ -412,7 +356,7 @@
   gap: 12px;
   font-size: 12px;
   color: var(--gray-10);
-  white-space: nowrap;
+  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
 
 .node-detail-value-stack {
@@ -423,7 +367,8 @@
 }
 
 .node-detail-value-line {
-  white-space: nowrap;
+  white-space: normal;
+  overflow-wrap: break-word;
 }
 
 .node-detail-runtime-stack {
@@ -457,6 +402,7 @@
   font-weight: 600;
   color: var(--gray-12);
   white-space: nowrap;
+  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
 
 .node-detail-latency-inline {
@@ -511,6 +457,7 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
 
 .node-detail-latency-cell.name {
@@ -520,8 +467,8 @@
 .node-detail-chart-card {
   background: var(--color-panel-solid);
   border: 1px solid var(--gray-a3);
-  border-radius: 20px;
-  padding: 16px;
+  border-radius: 12px;
+  padding: 20px;
   box-shadow: 0 18px 40px -32px rgba(15, 23, 42, 0.45);
 }
 
@@ -535,7 +482,7 @@
 
 .node-detail-toggle {
   background: var(--gray-a2);
-  border-radius: 999px;
+  border-radius: 6px;
   padding: 2px;
 }
 
@@ -557,6 +504,37 @@
     opacity: 1;
     transform: translateY(0);
   }
+}
+
+.dark .node-detail-card,
+.dark .node-detail-hero,
+.dark .node-detail-chart-card {
+  background: var(--card);
+  border-color: var(--border);
+}
+
+.dark .node-detail-status {
+  border-color: var(--gray-a5);
+}
+
+.dark .node-detail-status.online {
+  background: var(--green-a3);
+  border-color: var(--green-a5);
+  color: var(--green-12);
+}
+
+.dark .node-detail-status.online::before {
+  box-shadow: 0 0 0 3px var(--green-a4);
+}
+
+.dark .node-detail-status.offline {
+  background: var(--red-a3);
+  border-color: var(--red-a5);
+  color: var(--red-12);
+}
+
+.dark .node-detail-status.offline::before {
+  box-shadow: 0 0 0 3px var(--red-a4);
 }
 
 @media (min-width: 1400px) {
@@ -613,19 +591,11 @@
 
   .node-detail-hero {
     padding: 16px;
-    border-radius: 20px;
+    border-radius: 12px;
   }
 
   .node-detail-name {
     font-size: 20px;
-  }
-
-  .node-detail-hero-info {
-    grid-template-columns: 1fr;
-  }
-
-  .node-detail-hero-value {
-    white-space: normal;
   }
 
   .node-detail-os-icon {
@@ -638,24 +608,12 @@
     display: none;
   }
 
-  .node-detail-meta {
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  }
-
   .node-detail-section-grid {
     grid-template-columns: 1fr;
   }
 
-  .node-detail-card {
-    padding: 14px;
-  }
-
   .node-detail-body {
     gap: 12px;
-  }
-
-  .node-detail-row-value {
-    max-width: 100%;
   }
 
   .node-detail-runtime-row {
@@ -664,10 +622,6 @@
 
   .node-detail-latency-body {
     height: 180px;
-  }
-
-  .node-detail-chart-card {
-    padding: 12px;
   }
 
   .node-detail-chart-header {


### PR DESCRIPTION
##  Summary

Refactors the node detail page (`src/pages/instance`) with a focus on a cleaner, more consistent visual style and better CJK text rendering. 

> [!IMPORTANT]
> This is a **UI-only change** — no data flow or business logic is touched.
> This PR was reviewed and optimized with the assistance of AI. 
> The final code has been thoroughly manually verified, built, and tested by the author to ensure quality and stability.

---

##  Changes

###  UI & Layout
- **Layout**: Removed the redundant hero info bar; moved `uptime` / `last_updated` into the runtime info card, and relocated the version badge into the title row.
- **Styling**: Unified border-radius across cards, badges, and selectors to a softer, consistent scale (`999px/24px/20px` → `4px/6px/12px`).
- **Dark Mode**: Added explicit `.dark` overrides for card, hero, and status colors.

###  Typography & CJK Rendering
- **Font Smoothing**: Enabled `-webkit-font-smoothing: antialiased` and `text-rendering: optimizeLegibility`.
- **CJK Optimization**: Applied the monospace stack *only* to numeric/value cells to avoid CJK fallback blur.
- **Maintainability**: Extracted the repeated IBM Plex Mono font stack into a `--mono-font` CSS variable.

###  Mobile & Chore
- **Mobile Interaction**: Simplified `DetailRow` — long values now wrap inline instead of requiring a long-press dialog.
- **Chore**: Added Bun-related entries to `.gitignore`.

---

##  Testing

- [x] `tsc -b` passes with no errors
- [x] `eslint` passes with no warnings
- [x] `vite build` succeeds

---

##  Notes

The mobile `DetailRow` no longer uses a long-press dialog for truncated values — long content now wraps and stays fully visible. Flagging this as an **intentional interaction change** in case it needs discussion.

---

##  Screenshots

| Before | After |
| :---: | :---: |
 | <img width="1651" height="1159" alt="After" src="https://github.com/user-attachments/assets/baae350e-4f6c-47c9-b652-7e384a6bf20b" /> |<img width="1651" height="1159" alt="Before" src="https://github.com/user-attachments/assets/df18c892-3d6e-4a0d-a753-97cf0f79cf5e" />|