### PR TITLE
fix: fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,4 +93,4 @@ SOFTWARE.
 ```
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=svnmoe/komari-web-mochi&type=Date)](https://www.star-history.com/#svnmoe/komari-web-mochi&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=svnmoe/komari-web-mochi&type=Date)](https://star-history.dera.page/#svnmoe/komari-web-mochi&Date)


### PR DESCRIPTION
The star history chart in the README is currently broken because of GitHub stargazer API restrictions. This change points the chart to a working alternative so it displays correctly again.